### PR TITLE
Use two seperate out_map variables

### DIFF
--- a/src/video_core/renderer_opengl/gl_shaders.h
+++ b/src/video_core/renderer_opengl/gl_shaders.h
@@ -48,10 +48,11 @@ const char g_fragment_shader_hw[] = R"(
 in vec4 o[7];
 
 uniform sampler2D tex[3];
-uniform int out_maps[7];
+uniform int out_maps1[7];
+uniform int out_maps2[7];
 
 void main(void) {
-    gl_FragColor = o[out_maps[2]] * texture(tex[0], o[out_maps[3]].xy);
+    gl_FragColor = o[out_maps1[2]] * texture(tex[0], o[out_maps2[3]].xy);
 }
 )";
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -494,7 +494,8 @@ void RendererOpenGL::BeginBatch() {
         uniform_i = glGetUniformLocation(g_cur_shader, "i");
 
         uniform_tex = glGetUniformLocation(g_cur_shader, "tex");
-        uniform_out_maps = glGetUniformLocation(g_cur_shader, "out_maps");
+        uniform_out_maps1 = glGetUniformLocation(g_cur_shader, "out_maps1");
+        uniform_out_maps2 = glGetUniformLocation(g_cur_shader, "out_maps2");
 
         glUniform1i(uniform_tex, 0);
         glUniform1i(uniform_tex + 1, 1);
@@ -517,7 +518,8 @@ void RendererOpenGL::BeginBatch() {
         // TODO: actually assign each component semantics, not just whole-vec4's
         // Also might only need to do this once per shader?
         if (output_register_map.map_x.Value() % 4 == 0) {
-            glUniform1i(uniform_out_maps + output_register_map.map_x.Value() / 4, i);
+            glUniform1i(uniform_out_maps1 + output_register_map.map_x.Value() / 4, i);
+            glUniform1i(uniform_out_maps2 + output_register_map.map_x.Value() / 4, i);
         }
 
         //for (int comp = 0; comp < 4; ++comp)

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -103,5 +103,6 @@ private:
     GLuint uniform_b;
     GLuint uniform_i;
     GLuint uniform_tex;
-    GLuint uniform_out_maps;
+    GLuint uniform_out_maps1;
+    GLuint uniform_out_maps2;
 };


### PR DESCRIPTION
I don't know if you want pull requests for this branch or not, but this was kind of a big issue I experienced. Instead of taking away the requirement if IS_CAVE_STORY, for me that commit caused both Cave Story and Ocarina of Time to look like pixel barf:
![pixelbarf](https://cloud.githubusercontent.com/assets/3057954/6519430/bbf6a860-c381-11e4-902a-73e7eae9620b.png)
The problem was that out_maps was being used for two different values in the fragment shader at the same time, which caused the aforementioned issue. Having two out_maps variables solves the issue and both games work as expected on the same build.
