### PR TITLE
Use two seperate out_map variables

### DIFF
--- a/src/video_core/renderer_opengl/gl_shaders.h
+++ b/src/video_core/renderer_opengl/gl_shaders.h
@@ -48,11 +48,12 @@ const char g_vertex_shader_hw[] = R"(
 in vec4 v[8];
 out vec4 o[7];
 
-uniform int out_maps[7];
+uniform int out_maps1[7];
+uniform int out_maps2[7];
 
 void main() {
-    o[out_maps[2]] = v[1];
-    o[out_maps[3]] = v[2];
+    o[out_maps1[2]] = v[1];
+    o[out_maps2[3]] = v[2];
     gl_Position = v[0];
 }
 )";
@@ -68,7 +69,8 @@ uniform float alphatest_ref;
 
 uniform sampler2D tex[3];
 uniform ivec4 tevs[6];
-uniform int out_maps[7];
+uniform int out_maps1[7];
+uniform int out_maps2[7];
 
 vec4 g_last_tex_env_out;
 
@@ -80,7 +82,7 @@ void ProcessTexEnv(int tex_env_idx) {
 
     // TODO: make this actually do tex env stuff
 
-    g_last_tex_env_out = o[out_maps[2]] * texture(tex[0], o[out_maps[3]].xy);
+    g_last_tex_env_out = o[out_maps1[2]] * texture(tex[0], o[out_maps2[3]].xy);
 }
 
 void main(void) {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -224,7 +224,8 @@ void RendererOpenGL::InitOpenGLObjects() {
 
     uniform_tex = glGetUniformLocation(hw_program_id, "tex");
     uniform_tevs = glGetUniformLocation(hw_program_id, "tevs");
-    uniform_out_maps = glGetUniformLocation(hw_program_id, "out_maps");
+    uniform_out_maps1 = glGetUniformLocation(hw_program_id, "out_maps1");
+    uniform_out_maps2 = glGetUniformLocation(hw_program_id, "out_maps2");
 
     glUniform1i(uniform_tex, 0);
     glUniform1i(uniform_tex + 1, 1);
@@ -560,7 +561,8 @@ void RendererOpenGL::BeginBatch() {
 
         uniform_tex = glGetUniformLocation(g_cur_shader, "tex");
         uniform_tevs = glGetUniformLocation(g_cur_shader, "tevs");
-        uniform_out_maps = glGetUniformLocation(g_cur_shader, "out_maps");
+        uniform_out_maps1 = glGetUniformLocation(g_cur_shader, "out_maps1");
+        uniform_out_maps2 = glGetUniformLocation(g_cur_shader, "out_maps2");
 
         glUniform1i(uniform_tex, 0);
         glUniform1i(uniform_tex + 1, 1);
@@ -584,7 +586,8 @@ void RendererOpenGL::BeginBatch() {
         // TODO: actually assign each component semantics, not just whole-vec4's
         // Also might only need to do this once per shader?
         if (output_register_map.map_x.Value() % 4 == 0) {
-            glUniform1i(uniform_out_maps + output_register_map.map_x.Value() / 4, i);
+            glUniform1i(uniform_out_maps1 + output_register_map.map_x.Value() / 4, i);
+            glUniform1i(uniform_out_maps2 + output_register_map.map_x.Value() / 4, i);
         }
 
         //for (int comp = 0; comp < 4; ++comp)

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -119,6 +119,7 @@ private:
     GLuint uniform_alphatest_ref;
     GLuint uniform_tex;
     GLuint uniform_tevs;
-    GLuint uniform_out_maps;
+    GLuint uniform_out_maps1;
+    GLuint uniform_out_maps2;
     GLuint uniform_tex_envs;
 };


### PR DESCRIPTION
Both Cave Story and Ocarina of Time look like pixel barf:
![pixelbarf](https://cloud.githubusercontent.com/assets/3057954/6519430/bbf6a860-c381-11e4-902a-73e7eae9620b.png)
out_maps was being used for two different values in the shader at the same time, which doesn't seem to go over well. Using two seperate variables seems to fix the issue and both games display fine.
