### PR TITLE
Add renderer INI setting and remove USE_OGL_HD

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -65,6 +65,7 @@ void Config::ReadValues() {
     // Core
     Settings::values.gpu_refresh_rate = glfw_config->GetInteger("Core", "gpu_refresh_rate", 30);
     Settings::values.frame_skip = glfw_config->GetInteger("Core", "frame_skip", 0);
+    Settings::values.gfx_backend = glfw_config->Get("Core", "gfx_backend", "SW");
 
     // Data Storage
     Settings::values.use_virtual_sd = glfw_config->GetBoolean("Data Storage", "use_virtual_sd", true);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -41,6 +41,10 @@ gpu_refresh_rate =
 # 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
 frame_skip =
 
+# The graphics backend to use for rendering
+# SW : Software, OGL : OpenGL
+gfx_backend = SW
+
 [Data Storage]
 # Whether to create a virtual SD card.
 # 1 (default): Yes, 0: No

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -51,6 +51,7 @@ void Config::ReadValues() {
     qt_config->beginGroup("Core");
     Settings::values.gpu_refresh_rate = qt_config->value("gpu_refresh_rate", 30).toInt();
     Settings::values.frame_skip = qt_config->value("frame_skip", 0).toInt();
+    Settings::values.gfx_backend = qt_config->value("gfx_backend", "SW").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");
@@ -96,6 +97,7 @@ void Config::SaveValues() {
     qt_config->beginGroup("Core");
     qt_config->setValue("gpu_refresh_rate", Settings::values.gpu_refresh_rate);
     qt_config->setValue("frame_skip", Settings::values.frame_skip);
+    qt_config->setValue("gfx_backend", QString::fromStdString(Settings::values.gfx_backend));
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -37,6 +37,7 @@ struct Values {
     // Core
     int gpu_refresh_rate;
     int frame_skip;
+    std::string gfx_backend;
 
     // Data Storage
     bool use_virtual_sd;

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -12,6 +12,7 @@
 #include "pica.h"
 #include "primitive_assembly.h"
 #include "vertex_shader.h"
+#include "core/settings.h"
 #include "core/hle/service/gsp_gpu.h"
 #include "core/hw/gpu.h"
 
@@ -117,198 +118,15 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
             PrimitiveAssembler<DebugUtils::GeometryDumper::Vertex> dumping_primitive_assembler(registers.triangle_topology.Value());
             PrimitiveAssembler<RawVertex> ogl_primitive_assembler(registers.triangle_topology.Value());
 
-#ifndef USE_OGL_RENDERER
-            for (unsigned int index = 0; index < registers.num_vertices; ++index)
-            {
-                unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
+            if (!Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0) {
+                for (unsigned int index = 0; index < registers.num_vertices; ++index)
+                {
+                    unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
 
-                if (is_indexed) {
-                    // TODO: Implement some sort of vertex cache!
-                }
-
-                // Initialize data for the current vertex
-                VertexShader::InputVertex input;
-
-                // Load a debugging token to check whether this gets loaded by the running
-                // application or not.
-                static const float24 debug_token = float24::FromRawFloat24(0x00abcdef);
-                input.attr[0].w = debug_token;
-
-                for (int i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
-                    for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
-                        const u8* srcdata = Memory::GetPointer(PAddrToVAddr(vertex_attribute_sources[i] + vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i]));
-
-                        // TODO(neobrain): Ocarina of Time 3D has GetNumTotalAttributes return 8,
-                        // yet only provides 2 valid source data addresses. Need to figure out
-                        // what's wrong there, until then we just continue when address lookup fails
-                        if (srcdata == nullptr)
-                            continue;
-
-                        const float srcval = (vertex_attribute_formats[i] == 0) ? *(s8*)srcdata :
-                                             (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
-                                             (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
-                                                                                  *(float*)srcdata;
-                        input.attr[i][comp] = float24::FromFloat32(srcval);
-                        LOG_TRACE(HW_GPU, "Loaded component %x of attribute %x for vertex %x (index %x) from 0x%08x + 0x%08lx + 0x%04lx: %f",
-                                  comp, i, vertex, index,
-                                  attribute_config.GetPhysicalBaseAddress(),
-                                  vertex_attribute_sources[i] - base_address,
-                                  vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i],
-                                  input.attr[i][comp].ToFloat32());
+                    if (is_indexed) {
+                        // TODO: Implement some sort of vertex cache!
                     }
-                }
 
-                // HACK: Some games do not initialize the vertex position's w component. This leads
-                //       to critical issues since it messes up perspective division. As a
-                //       workaround, we force the fourth component to 1.0 if we find this to be the
-                //       case.
-                //       To do this, we additionally have to assume that the first input attribute
-                //       is the vertex position, since there's no information about this other than
-                //       the empiric observation that this is usually the case.
-                if (input.attr[0].w == debug_token)
-                    input.attr[0].w = float24::FromFloat32(1.0);
-
-                if (g_debug_context)
-                    g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, (void*)&input);
-
-                // NOTE: When dumping geometry, we simply assume that the first input attribute
-                //       corresponds to the position for now.
-                DebugUtils::GeometryDumper::Vertex dumped_vertex = {
-                    input.attr[0][0].ToFloat32(), input.attr[0][1].ToFloat32(), input.attr[0][2].ToFloat32()
-                };
-                using namespace std::placeholders;
-                dumping_primitive_assembler.SubmitVertex(dumped_vertex,
-                                                         std::bind(&DebugUtils::GeometryDumper::AddTriangle,
-                                                                   &geometry_dumper, _1, _2, _3));
-
-                // Send to vertex shader
-                VertexShader::OutputVertex output = VertexShader::RunShader(input, attribute_config.GetNumTotalAttributes());
-
-                if (is_indexed) {
-                    // TODO: Add processed vertex to vertex cache!
-                }
-
-                // Send to triangle clipper
-                clipper_primitive_assembler.SubmitVertex(output, Clipper::ProcessTriangle);
-            }
-#else // #ifndef USE_OGL_RENDERER
-            // TODO: pass in registers.triangle_topology.Value(), use that instead of splitting into triangles always
-#ifdef USE_OGL_VTXSHADER
-            ((RendererOpenGL *)VideoCore::g_renderer)->BeginBatch();
-
-            for (unsigned int index = 0; index < registers.num_vertices; ++index)
-            {
-                unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
-
-                RawVertex new_vert;
-
-                int num_attributes = attribute_config.GetNumTotalAttributes();
-                const auto& attribute_register_map = registers.vs_input_register_map;
-
-                RawVertex temp_vertex;
-
-                // Load a debugging token to check whether this gets loaded by the running
-                // application or not.
-                static const float debug_token = 123.456f;
-                temp_vertex.attribs[0][3] = debug_token;
-
-                for (int i = 0; i < num_attributes; ++i) {
-                    for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
-                        const u8* srcdata = Memory::GetPointer(PAddrToVAddr(vertex_attribute_sources[i] + vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i]));
-
-                        // TODO(neobrain): Ocarina of Time 3D has GetNumTotalAttributes return 8,
-                        // yet only provides 2 valid source data addresses. Need to figure out
-                        // what's wrong there, until then we just continue when address lookup fails
-                        if (srcdata == nullptr)
-                            continue;
-
-                        temp_vertex.attribs[i][comp] = (vertex_attribute_formats[i] == 0) ? *(s8*)srcdata :
-                            (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
-                            (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
-                            *(float*)srcdata;
-                    }
-                }
-
-                // HACK: Some games do not initialize the vertex position's w component. This leads
-                //       to critical issues since it messes up perspective division. As a
-                //       workaround, we force the fourth component to 1.0 if we find this to be the
-                //       case.
-                //       To do this, we additionally have to assume that the first input attribute
-                //       is the vertex position, since there's no information about this other than
-                //       the empiric observation that this is usually the case.
-                if (temp_vertex.attribs[0][3] == debug_token)
-                    temp_vertex.attribs[0][3] = 1.0f;
-
-                if (num_attributes > 0) {
-                    new_vert.attribs[attribute_register_map.attribute0_register][0] = temp_vertex.attribs[0][0];
-                    new_vert.attribs[attribute_register_map.attribute0_register][1] = temp_vertex.attribs[0][1];
-                    new_vert.attribs[attribute_register_map.attribute0_register][2] = temp_vertex.attribs[0][2];
-                    new_vert.attribs[attribute_register_map.attribute0_register][3] = temp_vertex.attribs[0][3];
-                }
-                if (num_attributes > 1) {
-                    new_vert.attribs[attribute_register_map.attribute1_register][0] = temp_vertex.attribs[1][0];
-                    new_vert.attribs[attribute_register_map.attribute1_register][1] = temp_vertex.attribs[1][1];
-                    new_vert.attribs[attribute_register_map.attribute1_register][2] = temp_vertex.attribs[1][2];
-                    new_vert.attribs[attribute_register_map.attribute1_register][3] = temp_vertex.attribs[1][3];
-                }
-                if (num_attributes > 2) {
-                    new_vert.attribs[attribute_register_map.attribute2_register][0] = temp_vertex.attribs[2][0];
-                    new_vert.attribs[attribute_register_map.attribute2_register][1] = temp_vertex.attribs[2][1];
-                    new_vert.attribs[attribute_register_map.attribute2_register][2] = temp_vertex.attribs[2][2];
-                    new_vert.attribs[attribute_register_map.attribute2_register][3] = temp_vertex.attribs[2][3];
-                }
-                if (num_attributes > 3) {
-                    new_vert.attribs[attribute_register_map.attribute3_register][0] = temp_vertex.attribs[3][0];
-                    new_vert.attribs[attribute_register_map.attribute3_register][1] = temp_vertex.attribs[3][1];
-                    new_vert.attribs[attribute_register_map.attribute3_register][2] = temp_vertex.attribs[3][2];
-                    new_vert.attribs[attribute_register_map.attribute3_register][3] = temp_vertex.attribs[3][3];
-                }
-                if (num_attributes > 4) {
-                    new_vert.attribs[attribute_register_map.attribute4_register][0] = temp_vertex.attribs[4][0];
-                    new_vert.attribs[attribute_register_map.attribute4_register][1] = temp_vertex.attribs[4][1];
-                    new_vert.attribs[attribute_register_map.attribute4_register][2] = temp_vertex.attribs[4][2];
-                    new_vert.attribs[attribute_register_map.attribute4_register][3] = temp_vertex.attribs[4][3];
-                }
-                if (num_attributes > 5) {
-                    new_vert.attribs[attribute_register_map.attribute5_register][0] = temp_vertex.attribs[5][0];
-                    new_vert.attribs[attribute_register_map.attribute5_register][1] = temp_vertex.attribs[5][1];
-                    new_vert.attribs[attribute_register_map.attribute5_register][2] = temp_vertex.attribs[5][2];
-                    new_vert.attribs[attribute_register_map.attribute5_register][3] = temp_vertex.attribs[5][3];
-                }
-                if (num_attributes > 6) {
-                    new_vert.attribs[attribute_register_map.attribute6_register][0] = temp_vertex.attribs[6][0];
-                    new_vert.attribs[attribute_register_map.attribute6_register][1] = temp_vertex.attribs[6][1];
-                    new_vert.attribs[attribute_register_map.attribute6_register][2] = temp_vertex.attribs[6][2];
-                    new_vert.attribs[attribute_register_map.attribute6_register][3] = temp_vertex.attribs[6][3];
-                }
-                if (num_attributes > 7) {
-                    new_vert.attribs[attribute_register_map.attribute7_register][0] = temp_vertex.attribs[7][0];
-                    new_vert.attribs[attribute_register_map.attribute7_register][1] = temp_vertex.attribs[7][1];
-                    new_vert.attribs[attribute_register_map.attribute7_register][2] = temp_vertex.attribs[7][2];
-                    new_vert.attribs[attribute_register_map.attribute7_register][3] = temp_vertex.attribs[7][3];
-                }
-
-                ogl_primitive_assembler.SubmitVertex(new_vert, ProcessHWTriangle);
-            }
-
-            ((RendererOpenGL *)VideoCore::g_renderer)->EndBatch();
-#else 
-            ((RendererOpenGL *)VideoCore::g_renderer)->BeginBatch();
-
-            std::unordered_map<unsigned int, VertexShader::OutputVertex> vcache;
-
-            for (unsigned int index = 0; index < registers.num_vertices; ++index)
-            {
-                unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
-
-                VertexShader::OutputVertex output;
-
-                std::unordered_map<unsigned int, VertexShader::OutputVertex>::iterator cached_vert = vcache.find(vertex);
-
-                if (is_indexed && cached_vert != vcache.end()) {
-                    // TODO: Implement some sort of vertex cache!
-                    output = cached_vert->second;
-                } else {
                     // Initialize data for the current vertex
                     VertexShader::InputVertex input;
 
@@ -328,16 +146,16 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
                                 continue;
 
                             const float srcval = (vertex_attribute_formats[i] == 0) ? *(s8*)srcdata :
-                                (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
-                                (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
-                                *(float*)srcdata;
+                                                 (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
+                                                 (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
+                                                                                      *(float*)srcdata;
                             input.attr[i][comp] = float24::FromFloat32(srcval);
                             LOG_TRACE(HW_GPU, "Loaded component %x of attribute %x for vertex %x (index %x) from 0x%08x + 0x%08lx + 0x%04lx: %f",
-                                comp, i, vertex, index,
-                                attribute_config.GetPhysicalBaseAddress(),
-                                vertex_attribute_sources[i] - base_address,
-                                vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i],
-                                input.attr[i][comp].ToFloat32());
+                                      comp, i, vertex, index,
+                                      attribute_config.GetPhysicalBaseAddress(),
+                                      vertex_attribute_sources[i] - base_address,
+                                      vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i],
+                                      input.attr[i][comp].ToFloat32());
                         }
                     }
 
@@ -361,36 +179,219 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
                     };
                     using namespace std::placeholders;
                     dumping_primitive_assembler.SubmitVertex(dumped_vertex,
-                        std::bind(&DebugUtils::GeometryDumper::AddTriangle,
-                        &geometry_dumper, _1, _2, _3));
+                                                             std::bind(&DebugUtils::GeometryDumper::AddTriangle,
+                                                                       &geometry_dumper, _1, _2, _3));
 
                     // Send to vertex shader
-                    output = VertexShader::RunShader(input, attribute_config.GetNumTotalAttributes());
+                    VertexShader::OutputVertex output = VertexShader::RunShader(input, attribute_config.GetNumTotalAttributes());
 
                     if (is_indexed) {
                         // TODO: Add processed vertex to vertex cache!
-                        vcache.emplace(vertex, output);
                     }
+
+                    // Send to triangle clipper
+                    clipper_primitive_assembler.SubmitVertex(output, Clipper::ProcessTriangle);
                 }
+            } else {
+                // TODO: pass in registers.triangle_topology.Value(), use that instead of splitting into triangles always
+#ifdef USE_OGL_VTXSHADER
+                ((RendererOpenGL *)VideoCore::g_renderer)->BeginBatch();
+
+                for (unsigned int index = 0; index < registers.num_vertices; ++index)
+                {
+                    unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
+
+                    RawVertex new_vert;
+
+                    int num_attributes = attribute_config.GetNumTotalAttributes();
+                    const auto& attribute_register_map = registers.vs_input_register_map;
+
+                    RawVertex temp_vertex;
+
+                    // Load a debugging token to check whether this gets loaded by the running
+                    // application or not.
+                    static const float debug_token = 123.456f;
+                    temp_vertex.attribs[0][3] = debug_token;
+
+                    for (int i = 0; i < num_attributes; ++i) {
+                        for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
+                            const u8* srcdata = Memory::GetPointer(PAddrToVAddr(vertex_attribute_sources[i] + vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i]));
+
+                            // TODO(neobrain): Ocarina of Time 3D has GetNumTotalAttributes return 8,
+                            // yet only provides 2 valid source data addresses. Need to figure out
+                            // what's wrong there, until then we just continue when address lookup fails
+                            if (srcdata == nullptr)
+                                continue;
+
+                            temp_vertex.attribs[i][comp] = (vertex_attribute_formats[i] == 0) ? *(s8*)srcdata :
+                                (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
+                                (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
+                                *(float*)srcdata;
+                        }
+                    }
+
+                    // HACK: Some games do not initialize the vertex position's w component. This leads
+                    //       to critical issues since it messes up perspective division. As a
+                    //       workaround, we force the fourth component to 1.0 if we find this to be the
+                    //       case.
+                    //       To do this, we additionally have to assume that the first input attribute
+                    //       is the vertex position, since there's no information about this other than
+                    //       the empiric observation that this is usually the case.
+                    if (temp_vertex.attribs[0][3] == debug_token)
+                        temp_vertex.attribs[0][3] = 1.0f;
+
+                    if (num_attributes > 0) {
+                        new_vert.attribs[attribute_register_map.attribute0_register][0] = temp_vertex.attribs[0][0];
+                        new_vert.attribs[attribute_register_map.attribute0_register][1] = temp_vertex.attribs[0][1];
+                        new_vert.attribs[attribute_register_map.attribute0_register][2] = temp_vertex.attribs[0][2];
+                        new_vert.attribs[attribute_register_map.attribute0_register][3] = temp_vertex.attribs[0][3];
+                    }
+                    if (num_attributes > 1) {
+                        new_vert.attribs[attribute_register_map.attribute1_register][0] = temp_vertex.attribs[1][0];
+                        new_vert.attribs[attribute_register_map.attribute1_register][1] = temp_vertex.attribs[1][1];
+                        new_vert.attribs[attribute_register_map.attribute1_register][2] = temp_vertex.attribs[1][2];
+                        new_vert.attribs[attribute_register_map.attribute1_register][3] = temp_vertex.attribs[1][3];
+                    }
+                    if (num_attributes > 2) {
+                        new_vert.attribs[attribute_register_map.attribute2_register][0] = temp_vertex.attribs[2][0];
+                        new_vert.attribs[attribute_register_map.attribute2_register][1] = temp_vertex.attribs[2][1];
+                        new_vert.attribs[attribute_register_map.attribute2_register][2] = temp_vertex.attribs[2][2];
+                        new_vert.attribs[attribute_register_map.attribute2_register][3] = temp_vertex.attribs[2][3];
+                    }
+                    if (num_attributes > 3) {
+                        new_vert.attribs[attribute_register_map.attribute3_register][0] = temp_vertex.attribs[3][0];
+                        new_vert.attribs[attribute_register_map.attribute3_register][1] = temp_vertex.attribs[3][1];
+                        new_vert.attribs[attribute_register_map.attribute3_register][2] = temp_vertex.attribs[3][2];
+                        new_vert.attribs[attribute_register_map.attribute3_register][3] = temp_vertex.attribs[3][3];
+                    }
+                    if (num_attributes > 4) {
+                        new_vert.attribs[attribute_register_map.attribute4_register][0] = temp_vertex.attribs[4][0];
+                        new_vert.attribs[attribute_register_map.attribute4_register][1] = temp_vertex.attribs[4][1];
+                        new_vert.attribs[attribute_register_map.attribute4_register][2] = temp_vertex.attribs[4][2];
+                        new_vert.attribs[attribute_register_map.attribute4_register][3] = temp_vertex.attribs[4][3];
+                    }
+                    if (num_attributes > 5) {
+                        new_vert.attribs[attribute_register_map.attribute5_register][0] = temp_vertex.attribs[5][0];
+                        new_vert.attribs[attribute_register_map.attribute5_register][1] = temp_vertex.attribs[5][1];
+                        new_vert.attribs[attribute_register_map.attribute5_register][2] = temp_vertex.attribs[5][2];
+                        new_vert.attribs[attribute_register_map.attribute5_register][3] = temp_vertex.attribs[5][3];
+                    }
+                    if (num_attributes > 6) {
+                        new_vert.attribs[attribute_register_map.attribute6_register][0] = temp_vertex.attribs[6][0];
+                        new_vert.attribs[attribute_register_map.attribute6_register][1] = temp_vertex.attribs[6][1];
+                        new_vert.attribs[attribute_register_map.attribute6_register][2] = temp_vertex.attribs[6][2];
+                        new_vert.attribs[attribute_register_map.attribute6_register][3] = temp_vertex.attribs[6][3];
+                    }
+                    if (num_attributes > 7) {
+                        new_vert.attribs[attribute_register_map.attribute7_register][0] = temp_vertex.attribs[7][0];
+                        new_vert.attribs[attribute_register_map.attribute7_register][1] = temp_vertex.attribs[7][1];
+                        new_vert.attribs[attribute_register_map.attribute7_register][2] = temp_vertex.attribs[7][2];
+                        new_vert.attribs[attribute_register_map.attribute7_register][3] = temp_vertex.attribs[7][3];
+                    }
+
+                    ogl_primitive_assembler.SubmitVertex(new_vert, ProcessHWTriangle);
+                }
+
+                ((RendererOpenGL *)VideoCore::g_renderer)->EndBatch();
+#else 
+                ((RendererOpenGL *)VideoCore::g_renderer)->BeginBatch();
+
+                std::unordered_map<unsigned int, VertexShader::OutputVertex> vcache;
+
+                for (unsigned int index = 0; index < registers.num_vertices; ++index)
+                {
+                    unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
+
+                    VertexShader::OutputVertex output;
+
+                    std::unordered_map<unsigned int, VertexShader::OutputVertex>::iterator cached_vert = vcache.find(vertex);
+
+                    if (is_indexed && cached_vert != vcache.end()) {
+                        // TODO: Implement some sort of vertex cache!
+                        output = cached_vert->second;
+                    } else {
+                        // Initialize data for the current vertex
+                        VertexShader::InputVertex input;
+
+                        // Load a debugging token to check whether this gets loaded by the running
+                        // application or not.
+                        static const float24 debug_token = float24::FromRawFloat24(0x00abcdef);
+                        input.attr[0].w = debug_token;
+
+                        for (int i = 0; i < attribute_config.GetNumTotalAttributes(); ++i) {
+                            for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
+                                const u8* srcdata = Memory::GetPointer(PAddrToVAddr(vertex_attribute_sources[i] + vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i]));
+
+                                // TODO(neobrain): Ocarina of Time 3D has GetNumTotalAttributes return 8,
+                                // yet only provides 2 valid source data addresses. Need to figure out
+                                // what's wrong there, until then we just continue when address lookup fails
+                                if (srcdata == nullptr)
+                                    continue;
+
+                                const float srcval = (vertex_attribute_formats[i] == 0) ? *(s8*)srcdata :
+                                    (vertex_attribute_formats[i] == 1) ? *(u8*)srcdata :
+                                    (vertex_attribute_formats[i] == 2) ? *(s16*)srcdata :
+                                    *(float*)srcdata;
+                                input.attr[i][comp] = float24::FromFloat32(srcval);
+                                LOG_TRACE(HW_GPU, "Loaded component %x of attribute %x for vertex %x (index %x) from 0x%08x + 0x%08lx + 0x%04lx: %f",
+                                    comp, i, vertex, index,
+                                    attribute_config.GetPhysicalBaseAddress(),
+                                    vertex_attribute_sources[i] - base_address,
+                                    vertex_attribute_strides[i] * vertex + comp * vertex_attribute_element_size[i],
+                                    input.attr[i][comp].ToFloat32());
+                            }
+                        }
+
+                        // HACK: Some games do not initialize the vertex position's w component. This leads
+                        //       to critical issues since it messes up perspective division. As a
+                        //       workaround, we force the fourth component to 1.0 if we find this to be the
+                        //       case.
+                        //       To do this, we additionally have to assume that the first input attribute
+                        //       is the vertex position, since there's no information about this other than
+                        //       the empiric observation that this is usually the case.
+                        if (input.attr[0].w == debug_token)
+                            input.attr[0].w = float24::FromFloat32(1.0);
+
+                        if (g_debug_context)
+                            g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, (void*)&input);
+
+                        // NOTE: When dumping geometry, we simply assume that the first input attribute
+                        //       corresponds to the position for now.
+                        DebugUtils::GeometryDumper::Vertex dumped_vertex = {
+                            input.attr[0][0].ToFloat32(), input.attr[0][1].ToFloat32(), input.attr[0][2].ToFloat32()
+                        };
+                        using namespace std::placeholders;
+                        dumping_primitive_assembler.SubmitVertex(dumped_vertex,
+                            std::bind(&DebugUtils::GeometryDumper::AddTriangle,
+                            &geometry_dumper, _1, _2, _3));
+
+                        // Send to vertex shader
+                        output = VertexShader::RunShader(input, attribute_config.GetNumTotalAttributes());
+
+                        if (is_indexed) {
+                            // TODO: Add processed vertex to vertex cache!
+                            vcache.emplace(vertex, output);
+                        }
+                    }
                 
-                RawVertex new_vert;
-                new_vert.attribs[0][0] = output.pos.x.ToFloat32();
-                new_vert.attribs[0][1] = -output.pos.y.ToFloat32();
-                new_vert.attribs[0][2] = -output.pos.z.ToFloat32();
-                new_vert.attribs[0][3] = output.pos.w.ToFloat32();
-                new_vert.attribs[1][0] = output.color.x.ToFloat32();
-                new_vert.attribs[1][1] = output.color.y.ToFloat32();
-                new_vert.attribs[1][2] = output.color.z.ToFloat32();
-                new_vert.attribs[1][3] = output.color.w.ToFloat32();
-                new_vert.attribs[2][0] = output.tc0.x.ToFloat32();
-                new_vert.attribs[2][1] = output.tc0.y.ToFloat32();
+                    RawVertex new_vert;
+                    new_vert.attribs[0][0] = output.pos.x.ToFloat32();
+                    new_vert.attribs[0][1] = -output.pos.y.ToFloat32();
+                    new_vert.attribs[0][2] = -output.pos.z.ToFloat32();
+                    new_vert.attribs[0][3] = output.pos.w.ToFloat32();
+                    new_vert.attribs[1][0] = output.color.x.ToFloat32();
+                    new_vert.attribs[1][1] = output.color.y.ToFloat32();
+                    new_vert.attribs[1][2] = output.color.z.ToFloat32();
+                    new_vert.attribs[1][3] = output.color.w.ToFloat32();
+                    new_vert.attribs[2][0] = output.tc0.x.ToFloat32();
+                    new_vert.attribs[2][1] = output.tc0.y.ToFloat32();
 
-                ogl_primitive_assembler.SubmitVertex(new_vert, ProcessHWTriangle);
-            }
+                    ogl_primitive_assembler.SubmitVertex(new_vert, ProcessHWTriangle);
+                }
 
-            ((RendererOpenGL *)VideoCore::g_renderer)->EndBatch();
+                ((RendererOpenGL *)VideoCore::g_renderer)->EndBatch();
 #endif
-#endif // #ifndef USE_OGL_RENDERER
+            }
 
             geometry_dumper.Dump();
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/settings.h"
 #include "core/hw/gpu.h"
 #include "core/hw/hw.h"
 #include "core/hw/lcd.h"
@@ -79,13 +80,13 @@ RendererOpenGL::~RendererOpenGL() {
 
 /// Swap buffers (render frame)
 void RendererOpenGL::SwapBuffers() {
-#ifdef USE_OGL_RENDERER
-    if (!g_did_render) {
-        return;
-    }
+    if (Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0) {
+        if (!g_did_render) {
+            return;
+        }
 
-    g_did_render = 0;
-#endif
+        g_did_render = 0;
+    }
 
     render_window->MakeCurrent();
 
@@ -115,17 +116,15 @@ void RendererOpenGL::SwapBuffers() {
                 ConfigureFramebufferTexture(textures[i], framebuffer);
                 ConfigureHWFramebuffer(i);
             }
-#ifndef USE_OGL_RENDERER
-        LoadFBToActiveGLTexture(GPU::g_regs.framebuffer_config[i], textures[i]);
-#endif
+            if (!Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0)
+                LoadFBToActiveGLTexture(GPU::g_regs.framebuffer_config[i], textures[i]);
 
             // Resize the texture in case the framebuffer size has changed
             textures[i].width = desired_size.x;
             textures[i].height = desired_size.y;
         }
-#ifndef USE_OGL_RENDERER
-        LoadFBToActiveGLTexture(GPU::g_regs.framebuffer_config[i], textures[i]);
-#endif
+        if (!Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0)
+            LoadFBToActiveGLTexture(GPU::g_regs.framebuffer_config[i], textures[i]);
     }
 
     glBindVertexArray(vertex_array_handle);
@@ -136,11 +135,11 @@ void RendererOpenGL::SwapBuffers() {
     glBindVertexArray(hw_vertex_array_handle);
     glUseProgram(hw_program_id);
 
-#ifdef USE_OGL_RENDERER
-    // TODO: check if really needed
-    //glFlush();
-    //glFinish();
-#endif
+    if (Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0) {
+        // TODO: check if really needed
+        //glFlush();
+        //glFinish();
+    }
 
     auto& profiler = Common::Profiling::GetProfilingManager();
     profiler.FinishFrame();
@@ -155,12 +154,12 @@ void RendererOpenGL::SwapBuffers() {
 
     profiler.BeginFrame();
 
-#ifdef USE_OGL_RENDERER
-    glBindFramebuffer(GL_FRAMEBUFFER, hw_framebuffers[0]);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glBindFramebuffer(GL_FRAMEBUFFER, hw_framebuffers[1]);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-#endif
+    if (Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0) {
+        glBindFramebuffer(GL_FRAMEBUFFER, hw_framebuffers[0]);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glBindFramebuffer(GL_FRAMEBUFFER, hw_framebuffers[1]);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
 }
 
 /**

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -298,21 +298,21 @@ void RendererOpenGL::InitOpenGLObjects() {
     glGenRenderbuffers(2, hw_framedepthbuffers);
 }
 
-Math::Vec2<u32> RendererOpenGL::GetDesiredFramebufferSize(TextureInfo& texture,
-															const GPU::Regs::FramebufferConfig& framebuffer) {
-#ifndef USE_OGL_HD
-	return Math::Vec2<u32>(framebuffer.width, framebuffer.height);
-#else
-    auto layout = render_window->GetFramebufferLayout();
-    Math::Vec2<u32> desired_size(layout.height / 2, layout.width);
+    Math::Vec2<u32> RendererOpenGL::GetDesiredFramebufferSize(TextureInfo& texture,
+            const GPU::Regs::FramebufferConfig& framebuffer) {
+    if (Settings::values.gfx_backend.substr(0, Settings::values.gfx_backend.find_first_of(" #")).compare("OGL") == 0) {
+        auto layout = render_window->GetFramebufferLayout();
+        Math::Vec2<u32> desired_size(layout.height / 2, layout.width);
 
-	if (texture.handle != textures[0].handle) {
-        desired_size.x *= ((float)VideoCore::kScreenBottomHeight / (float)VideoCore::kScreenTopHeight);
-		desired_size.y *= ((float)VideoCore::kScreenBottomWidth / (float)VideoCore::kScreenTopWidth);
-	}
+        if (texture.handle != textures[0].handle) {
+            desired_size.x *= ((float)VideoCore::kScreenBottomHeight / (float)VideoCore::kScreenTopHeight);
+            desired_size.y *= ((float)VideoCore::kScreenBottomWidth / (float)VideoCore::kScreenTopWidth);
+        }
 
-	return desired_size;
-#endif
+        return desired_size;
+    } else {
+        return Math::Vec2<u32>(framebuffer.width, framebuffer.height);
+    }
 }
 
 void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -15,7 +15,6 @@
 
 #include "video_core/renderer_base.h"
 
-#define USE_OGL_RENDERER
 #define USE_OGL_VTXSHADER
 #define USE_OGL_HD
 

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -16,7 +16,6 @@
 #include "video_core/renderer_base.h"
 
 #define USE_OGL_VTXSHADER
-#define USE_OGL_HD
 
 class EmuWindow;
 


### PR DESCRIPTION
This adds the INI setting from the ogl_renderer branch, modified for the proto-progress branch. It also removes the USE_OGL_HD define so now HD will always be enabled in OpenGL and disabled in software renderer. I'm not sure if it's worthwhile adding this feature to the proto-progress branch or not, because I don't know if the end goal is to use the slower but more accurate ogl-renderer branch or if it's to make the proto-progress branch more accurate while keeping decent speed. Either way, I had these commits in my custom branch, so I decided to submit them just because. If this doesn't get merged I won't really care.
Diffs always end up looking more complicated than they need to; the lines all got indented for the if statements, but the diff makes it seem like code is all over the place :P
